### PR TITLE
Verbosity header

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 1.4.0 / 2022-02-22
+
+- Demonstrated usage of the verbosity header
+
 ## 1.3.0 / 2022-01-27
 
 - Updated for AVEVA Data Hub

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | :loudspeaker: **Notice**: Samples have been updated to reflect that they work on AVEVA Data Hub. The samples also work on OSIsoft Cloud Services unless otherwise noted. |
 | -----------------------------------------------------------------------------------------------|  
 
-**Version:** 1.3.0
+**Version:** 1.4.0
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/ADH/aveva.sample-adh-data_views-java?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=2617&branchName=main)
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.github.osisoft.dataviewsample</groupId>
   <artifactId>dataviewsjava</artifactId>
-  <version>1.3.0</version>
+  <version>1.4.0</version>
 
   <name>dataviewsjava</name>
   <!-- FIXME change it to the project's website -->
@@ -22,7 +22,7 @@
       <dependency> 
         <groupId> com.github.osisoft.ocs_sample_library_preview</groupId>
         <artifactId>ocs_sample_library_preview</artifactId>
-        <version>[0.2.0-preview,)</version>
+        <version>[0.2.1-preview,)</version>
     </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/com/github/osisoft/dataviewsample/App.java
+++ b/src/main/java/com/github/osisoft/dataviewsample/App.java
@@ -304,15 +304,14 @@ public class App {
             System.out.println();
             System.out.println("Step 13: Demonstrate accept-verbosity header usage");
 
-            System.out.println("Writing null values to the streams");
+            System.out.println("Writing default values to one property of the stream");
             // Keep the times in the future, guaranteeing no overlaps with existing data
-            Instant null_data_start_time = Instant.now().plus(Duration.ofHours(1));
-            Instant null_data_end_time = null_data_start_time.plus(Duration.ofHours(1));
+            Instant default_data_start_time = Instant.now().plus(Duration.ofHours(1));
+            Instant default_data_end_time = default_data_start_time.plus(Duration.ofHours(1));
 
-            // The first value is only a pressure, keeping temperature as null. Vice versa for the second
-            String values = "[{\"time\": " + null_data_start_time + ", \"pressure\": 100},{\"time\": " + null_data_end_time + ", \"temperature\": 50}]";
+            // The values are only a pressure, keeping temperature as 0 (the default value of a non-nullable double data type)
+            String values = "[{\"time\": \"" + default_data_start_time + "\", \"pressure\": 100, \"temperature\":0},{\"time\": \"" + default_data_end_time + "\", \"pressure\": 50, \"temperature\":0}]";
             adhClient.Streams.updateValues(tenantId, namespaceId, sampleStreamId1, values);
-            adhClient.Streams.updateValues(tenantId, namespaceId, sampleStreamId2, values);
 
             System.out.println();
             System.out.println("Data View results will not include null values written to nullable properties if the accept-verbosity header is set to non-verbose.");
@@ -321,18 +320,18 @@ public class App {
             boolean verbose = true;
 
             System.out.println();
-            System.out.println("Retrieving these values in the data view with the default verbosity set to true should return default values (null, in this case)");
+            System.out.println("Retrieving these values in the data view with the default verbosity set to true should return default values (0, in this case)");
             dataViewStoredData = adhClient.DataViews.getDataViewStoredData(namespaceId, sampleDataViewId,
-                null_data_start_time.toString(), null_data_end_time.toString(), verbose).getResponse();
+                default_data_start_time.toString(), default_data_end_time.toString(), verbose).getResponse();
             System.out.println(dataViewStoredData);
             assert dataViewStoredData.length() > 0 : "Error getting data view stored data";
             
             verbose = false;
 
             System.out.println();
-            System.out.println("Retrieving these values in the data view with the verbosity set to false should prevent OCS from responding with default values (null, in this case)");
+            System.out.println("Retrieving these values in the data view with the verbosity set to false should prevent OCS from responding with default values (0, in this case)");
             dataViewStoredData = adhClient.DataViews.getDataViewStoredData(namespaceId, sampleDataViewId,
-                null_data_start_time.toString(), null_data_end_time.toString(), verbose).getResponse();
+                default_data_start_time.toString(), default_data_end_time.toString(), verbose).getResponse();
             System.out.println(dataViewStoredData);
             assert dataViewStoredData.length() > 0 : "Error getting data view stored data";
             

--- a/src/main/java/com/github/osisoft/dataviewsample/App.java
+++ b/src/main/java/com/github/osisoft/dataviewsample/App.java
@@ -300,13 +300,49 @@ public class App {
             System.out.println(dataViewStoredData);
             assert dataViewStoredData.length() > 0 : "Error getting data view stored data";
 
+            // Step 14
+            System.out.println();
+            System.out.println("Step 13: Demonstrate accept-verbosity header usage");
+
+            System.out.println("Writing null values to the streams");
+            // Keep the times in the future, guaranteeing no overlaps with existing data
+            Instant null_data_start_time = Instant.now().plus(Duration.ofHours(1));
+            Instant null_data_end_time = null_data_start_time.plus(Duration.ofHours(1));
+
+            // The first value is only a pressure, keeping temperature as null. Vice versa for the second
+            String values = "[{\"time\": " + null_data_start_time + ", \"pressure\": 100},{\"time\": " + null_data_end_time + ", \"temperature\": 50}]";
+            adhClient.Streams.updateValues(tenantId, namespaceId, sampleStreamId1, values);
+            adhClient.Streams.updateValues(tenantId, namespaceId, sampleStreamId2, values);
+
+            System.out.println();
+            System.out.println("Data View results will not include null values written to nullable properties if the accept-verbosity header is set to non-verbose.");
+            System.out.println("The values just written include nulls for one of the properties; note the presence or absense of these values in the following outputs:");
+            
+            boolean verbose = true;
+
+            System.out.println();
+            System.out.println("Retrieving these values in the data view with the default verbosity set to true should return default values (null, in this case)");
+            dataViewStoredData = adhClient.DataViews.getDataViewStoredData(namespaceId, sampleDataViewId,
+                null_data_start_time.toString(), null_data_end_time.toString(), verbose).getResponse();
+            System.out.println(dataViewStoredData);
+            assert dataViewStoredData.length() > 0 : "Error getting data view stored data";
+            
+            verbose = false;
+
+            System.out.println();
+            System.out.println("Retrieving these values in the data view with the verbosity set to false should prevent OCS from responding with default values (null, in this case)");
+            dataViewStoredData = adhClient.DataViews.getDataViewStoredData(namespaceId, sampleDataViewId,
+                null_data_start_time.toString(), null_data_end_time.toString(), verbose).getResponse();
+            System.out.println(dataViewStoredData);
+            assert dataViewStoredData.length() > 0 : "Error getting data view stored data";
+            
         } catch (Exception e) {
             e.printStackTrace();
             success = false;
         } finally {
-            // Step 14
+            // Step 15
             System.out.println();
-            System.out.println("Step 14: Delete sample objects from ADH");
+            System.out.println("Step 15: Delete sample objects from ADH");
             try {
                 System.out.println("Deleting data view...");
                 adhClient.DataViews.deleteDataView(namespaceId, sampleDataViewId);

--- a/src/main/java/com/github/osisoft/dataviewsample/App.java
+++ b/src/main/java/com/github/osisoft/dataviewsample/App.java
@@ -310,12 +310,20 @@ public class App {
             Instant default_data_end_time = default_data_start_time.plus(Duration.ofHours(1));
 
             // The values are only a pressure, keeping temperature as 0 (the default value of a non-nullable double data type)
-            String values = "[{\"time\": \"" + default_data_start_time + "\", \"pressure\": 100, \"temperature\":0},{\"time\": \"" + default_data_end_time + "\", \"pressure\": 50, \"temperature\":0}]";
+            ArrayList<String> values_array = new ArrayList<String>();
+
+            String val1 = ("{\"time\" : \"" + default_data_start_time + "\", \"pressure\": 100, \"temperature\":0}");
+            String val2 = ("{\"time\" : \"" + default_data_end_time + "\", \"pressure\": 50, \"temperature\":0}");
+            values_array.add(val1);
+            values_array.add(val2);
+
+            String values = "[" + String.join(",", values_array) + "]";
+
             adhClient.Streams.updateValues(tenantId, namespaceId, sampleStreamId1, values);
 
             System.out.println();
-            System.out.println("Data View results will not include null values written to nullable properties if the accept-verbosity header is set to non-verbose.");
-            System.out.println("The values just written include nulls for one of the properties; note the presence or absense of these values in the following outputs:");
+            System.out.println("Data View results will not include default values written to properties if the accept-verbosity header is set to non-verbose.");
+            System.out.println("The values just written to " + sampleStreamId1 + " include the default value of 0 for temperature; note the presence or absense of these values in the following outputs:");
             
             boolean verbose = true;
 

--- a/src/main/java/com/github/osisoft/dataviewsample/App.java
+++ b/src/main/java/com/github/osisoft/dataviewsample/App.java
@@ -329,7 +329,7 @@ public class App {
             verbose = false;
 
             System.out.println();
-            System.out.println("Retrieving these values in the data view with the verbosity set to false should prevent OCS from responding with default values (0, in this case)");
+            System.out.println("Retrieving these values in the data view with the verbosity set to false should prevent ADH from responding with default values (0, in this case)");
             dataViewStoredData = adhClient.DataViews.getDataViewStoredData(namespaceId, sampleDataViewId,
                 default_data_start_time.toString(), default_data_end_time.toString(), verbose).getResponse();
             System.out.println(dataViewStoredData);


### PR DESCRIPTION
Adds another step to the sequence in order to show the usage of the verbose parameter in the data retrieval routes. 

Nullable SDS types are not implemented in the library, so this sample writes 0 as the default value instead of sending null like the equivalent .NET and Python samples do. The outcome is the same in terms of the payload being shorter, but this was easier than expanding the SDS Type code to include the nullable types, and the appropriate handling for them.

This PR requires the corresponding library branch that's the scope of this PR: https://github.com/osisoft/sample-adh-sample_libraries-java/pull/21